### PR TITLE
Fix for the gemv benchmark to find the tritonblas library when run

### DIFF
--- a/benchmarks/benchmark_gemv.py
+++ b/benchmarks/benchmark_gemv.py
@@ -1,5 +1,9 @@
 import torch
 import triton
+
+from utils import add_tritonblas_lib
+
+add_tritonblas_lib()
 import tritonblas as tb
 
 


### PR DESCRIPTION
This is needed for make benchmarks or make benchmark_gemv to run successfully without first installing the library.