### PR TITLE
Consistent DEVICE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ BLAS routines written in Triton
 
 * dot
 * axpy
+* nrm2
 
 ### Level 2
 

--- a/benchmarks/benchmark_axpy.py
+++ b/benchmarks/benchmark_axpy.py
@@ -7,7 +7,7 @@ add_tritonblas_lib()
 import tritonblas as tb
 
 
-DEVICE = torch.accelerator.current_accelerator()
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 @triton.testing.perf_report(

--- a/benchmarks/benchmark_dot.py
+++ b/benchmarks/benchmark_dot.py
@@ -7,7 +7,7 @@ add_tritonblas_lib()
 import tritonblas as tb
 
 
-DEVICE = torch.accelerator.current_accelerator()
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 @triton.testing.perf_report(

--- a/benchmarks/benchmark_nrm2.py
+++ b/benchmarks/benchmark_nrm2.py
@@ -1,9 +1,13 @@
 import torch
 import triton
+
+from utils import add_tritonblas_lib
+
+add_tritonblas_lib()
 import tritonblas as tb
 
 
-DEVICE = "cuda"
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 @triton.testing.perf_report(

--- a/benchmarks/benchmark_nrm2.py
+++ b/benchmarks/benchmark_nrm2.py
@@ -28,12 +28,12 @@ def benchmark_nrm2(size, provider):
     quantiles = [0.5, 0.2, 0.8]
     if provider == 'torch':
         ms, min_ms, max_ms = triton.testing.do_bench(
-            lambda: torch.linalg.norm(x), quantiles=quantiles)
+            lambda: torch.sqrt(torch.sum(x * x)), quantiles=quantiles)
     if provider == 'triton':
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: tb.nrm2(x), quantiles=quantiles)
 
-    def gbps(ms): return x.numel() * x.element_size() / ms * 1e-6
+    def gbps(ms): return 2 * x.numel() * x.element_size() / ms * 1e-6
     return gbps(ms), gbps(max_ms), gbps(min_ms)
 
 
@@ -45,4 +45,4 @@ def test_nrm2(benchmark):
 
 
 if __name__ == "__main__":
-    benchmark_nrm2.run(print_data=True, show_plots=True) 
+    benchmark_nrm2.run(print_data=True, show_plots=False) 

--- a/benchmarks/benchmark_nrm2.py
+++ b/benchmarks/benchmark_nrm2.py
@@ -1,0 +1,48 @@
+import torch
+import triton
+import tritonblas as tb
+
+
+DEVICE = "cuda"
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=['size'],  # Argument names to use as an x-axis for the plot.
+        # Different possible values for `x_name`.
+        x_vals=[2**i for i in range(12, 28, 1)],
+        x_log=True,  # x axis is logarithmic.
+        # Argument name whose value corresponds to a different line in the plot.
+        line_arg='provider',
+        line_vals=['triton', 'torch'],  # Possible values for `line_arg`.
+        line_names=['Triton', 'Torch'],  # Label name for the lines.
+        styles=[('blue', '-'), ('green', '-')],  # Line styles.
+        ylabel='GB/s',  # Label name for the y-axis.
+        # Name for the plot. Used also as a file name for saving the plot.
+        plot_name='vector-nrm2-performance',
+        # Values for function arguments not in `x_names` and `y_name`.
+        args={},
+    ))
+def benchmark_nrm2(size, provider):
+    x = torch.rand(size, device=DEVICE, dtype=torch.float32)
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == 'torch':
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: torch.linalg.norm(x), quantiles=quantiles)
+    if provider == 'triton':
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: tb.nrm2(x), quantiles=quantiles)
+
+    def gbps(ms): return x.numel() * x.element_size() / ms * 1e-6
+    return gbps(ms), gbps(max_ms), gbps(min_ms)
+
+
+def test_nrm2(benchmark):
+    def run_nrm2_benchmark():
+        benchmark_nrm2.run(print_data=False, show_plots=False)
+
+    benchmark(run_nrm2_benchmark)
+
+
+if __name__ == "__main__":
+    benchmark_nrm2.run(print_data=True, show_plots=True) 

--- a/benchmarks/benchmark_nrm2.py
+++ b/benchmarks/benchmark_nrm2.py
@@ -28,7 +28,7 @@ def benchmark_nrm2(size, provider):
     quantiles = [0.5, 0.2, 0.8]
     if provider == 'torch':
         ms, min_ms, max_ms = triton.testing.do_bench(
-            lambda: torch.sqrt(torch.sum(x * x)), quantiles=quantiles)
+            lambda: torch.linalg.norm(x), quantiles=quantiles)
     if provider == 'triton':
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: tb.nrm2(x), quantiles=quantiles)

--- a/tests/test_axpy.py
+++ b/tests/test_axpy.py
@@ -5,7 +5,7 @@ from triton.testing import assert_close
 from .utils import get_rtol
 
 
-DEVICE = triton.runtime.driver.active.get_current_target().backend
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def test_axpy():

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -5,7 +5,7 @@ from triton.testing import assert_close
 from .utils import get_rtol
 
 
-DEVICE = triton.runtime.driver.active.get_current_target().backend
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def test_dot():

--- a/tests/test_nrm2.py
+++ b/tests/test_nrm2.py
@@ -15,4 +15,4 @@ def test_nrm2():
     triton_output = tb.nrm2(x)
     torch.output = torch.linalg.norm(x)
     
-    
+    assert_close(triton_output, torch_output, rtol=rtol)

--- a/tests/test_nrm2.py
+++ b/tests/test_nrm2.py
@@ -5,7 +5,7 @@ import tritonblas as tb
 from .utils import get_rtol
 
 
-DEVICE = triton.runtime.driver.active.get_current_target().backend
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
 def test_nrm2():

--- a/tests/test_nrm2.py
+++ b/tests/test_nrm2.py
@@ -2,17 +2,21 @@ import torch
 import triton
 from triton.testing import assert_close
 import tritonblas as tb
+from .utils import get_rtol
 
 
-DEVICE = "cuda"
+DEVICE = triton.runtime.driver.active.get_current_target().backend
+
 
 def test_nrm2():
     size = 98432
 
     torch.manual_seed(0)
-    x = torch.randn(size, device=DEVICE, dtype=torch.float16)
+    dtype = torch.float32
+    x = torch.randn(size, device=DEVICE, dtype=dtype)
 
     triton_output = tb.nrm2(x)
-    torch.output = torch.linalg.norm(x)
+    torch_output = torch.linalg.norm(x)
     
+    rtol = get_rtol()
     assert_close(triton_output, torch_output, rtol=rtol)

--- a/tests/test_nrm2.py
+++ b/tests/test_nrm2.py
@@ -1,0 +1,18 @@
+import torch
+import triton
+from triton.testing import assert_close
+import tritonblas as tb
+
+
+DEVICE = "cuda"
+
+def test_nrm2():
+    size = 98432
+
+    torch.manual_seed(0)
+    x = torch.randn(size, device=DEVICE, dtype=torch.float16)
+
+    triton_output = tb.nrm2(x)
+    torch.output = torch.linalg.norm(x)
+    
+    

--- a/tritonblas/__init__.py
+++ b/tritonblas/__init__.py
@@ -1,6 +1,7 @@
 # Level 1 BLAS functions
 from .level1.dot import dot
 from .level1.axpy import axpy
+from .level1.nrm2 import nrm2
 
 # Level 2 BLAS functions
 

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -48,5 +48,4 @@ def get_autotune_config():
 
 @triton.jit
 def nrm2_kernel(
-    
 )

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -3,9 +3,6 @@ import triton
 import triton.language as tl
 
 
-DEVICE = triton.runtime.driver.active.get_current_target().backend
-
-
 def get_autotune_config():
     return [
         triton.Config(

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -111,14 +111,14 @@ def nrm2(x: torch.Tensor):
     Returns:
         L2 norm of the input tensor (scalar).
     """
-    output = torch.zeros((1,))
+    output = torch.zeros((1,), device=x.device)
     assert x.device == output.device
     n_elements = x.numel()
 
     # Allocate enough memory for the partial sums
     min_block_size = min(config.kwargs['BLOCK_SIZE'] for config in get_autotune_config())
     max_partial_programs = triton.cdiv(n_elements, min_block_size)
-    partial_sums = torch.zeros(max_partial_programs)
+    partial_sums = torch.zeros(max_partial_programs, device=x.device)
 
     # Capture the actual grid size used by autotuning
     auto_grid = None

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -3,6 +3,9 @@ import triton
 import triton.language as tl
 
 
+DEVICE = triton.runtime.driver.active.get_current_target().backend
+
+
 def get_autotune_config():
     return [
         triton.Config(
@@ -42,39 +45,102 @@ def get_autotune_config():
     configs=get_autotune_config(),
     key=["n_elements"]
 )
-
-
 @triton.jit
-def nrm2_kernel(
+def nrm2_partial(
     x_ptr,
-    output_ptr,
+    partial_ptr,
     n_elements,
     BLOCK_SIZE: tl.constexpr
 ):
+    """Kernel to compute the partial sums of the squares of the elements of the input tensor.
+
+    Args:
+        x_ptr: Pointer to the input tensor.
+        partial_ptr: Pointer to the partial sums.
+        n_elements: Number of elements in the input tensor.
+        BLOCK_SIZE: Block size autotuned by the compiler.
+    """
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
     x = tl.load(x_ptr + offsets, mask=mask)
-    
-    partial = tl.sum(x * x)  # sum of squares for a program's assigned chunk
-    total = tl.sum(partial[None], axis=0)  # sum scalars from all programs
-    output = tl.sqrt(total)  # square root of total 
 
-    tl.store(output_ptr, output)
+    exp = x * x
+    sum_of_squares = tl.sum(exp)
+    
+    tl.store(partial_ptr + pid, sum_of_squares)
+
+
+@triton.jit
+def nrm2_final(
+    partial_ptr,
+    final_ptr,
+    n_partial,
+):
+    """Kernel to compute the final sum of the partial sums.
+
+    Args:
+        partial_ptr: Pointer to the partial sums.
+        final_ptr: Pointer to the final sum.
+        n_partial: Number of partial sums calculated by the partial kernel.
+    """
+    total = tl.zeros((), dtype=tl.float32)
+    
+    # Process partial sums
+    for i in range(n_partial):
+        partial_val = tl.load(partial_ptr + i)
+        total += partial_val
+    
+    tl.store(final_ptr, total)
 
 
 def nrm2(x: torch.Tensor):
-    output = torch.empty(())  # output is a single scalar value
+    """Compute the L2 norm of a tensor using a two-kernel parallel reduction.
+
+    Workflow:
+    1. Partial Kernel (Distributed): Divides the input vector into blocks,
+       where each GPU thread block computes the sum of squares for its assigned
+       chunk of elements. This produces multiple partial sums.
+       
+    2. Final Kernel (Reduction): A single thread sequentially sums all the
+       partial sums from step 1 to get the total sum of squares.
+       
+    3. Square Root: Takes the square root of the total sum to get the L2 norm.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        L2 norm of the input tensor (scalar).
+    """
+    output = torch.zeros((1,))
     assert x.device == output.device
     n_elements = x.numel()
 
-    def grid(META): return (triton.cdiv(n_elements, META['BLOCK_SIZE']), )
+    # Allocate enough memory for the partial sums
+    min_block_size = min(config.kwargs['BLOCK_SIZE'] for config in get_autotune_config())
+    max_partial_programs = triton.cdiv(n_elements, min_block_size)
+    partial_sums = torch.zeros(max_partial_programs)
 
-    nrm2_kernel[grid](
+    # Capture the actual grid size used by autotuning
+    auto_grid = None
+    def grid(META):
+        nonlocal auto_grid
+        auto_grid = triton.cdiv(n_elements, META['BLOCK_SIZE'])
+        return (auto_grid,)
+    
+    nrm2_partial[grid](
         x,
-        output,
+        partial_sums,
         n_elements
     )
-    
-    return output
+
+    nrm2_final[(1,)](
+        partial_sums,
+        output,
+        auto_grid
+    )
+
+    result = torch.sqrt(output)
+    return result

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -65,9 +65,9 @@ def nrm2_kernel(
 
 
 def nrm2(x: torch.Tensor):
-    output = torch.Tensor()  # output is a single scalar value
+    output = torch.empty(())  # output is a single scalar value
     assert x.device == output.device
-    n_elements = output.numel()
+    n_elements = x.numel()
 
     def grid(META): return (triton.cdiv(n_elements, META['BLOCK_SIZE']), )
 

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+
+def is_cuda():
+    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+def get_autotune_config():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE": 1024,
+            },
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE": 524,
+            },
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE": 256,
+            },
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE": 128,
+            },
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE": 64,
+            },
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE": 32,
+            },
+        ),
+    ]
+
+
+@triton.autotune(
+    configs=get_autotune_config(),
+    key=["n_elements"]
+)
+
+
+@triton.jit
+def nrm2_kernel(
+    
+)

--- a/tritonblas/level1/nrm2.py
+++ b/tritonblas/level1/nrm2.py
@@ -2,8 +2,6 @@ import torch
 import triton
 import triton.language as tl
 
-def is_cuda():
-    return triton.runtime.driver.active.get_current_target().backend == "cuda"
 
 def get_autotune_config():
     return [
@@ -48,4 +46,35 @@ def get_autotune_config():
 
 @triton.jit
 def nrm2_kernel(
-)
+    x_ptr,
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    
+    partial = tl.sum(x**2)
+    total = tl.reduce(partial, axis=0, op=tl.sum)
+    output = tl.sqrt(total)
+
+    tl.store(output_ptr, output)
+
+
+def nrm2(x: torch.Tensor, y: torch.Tensor):
+    output = torch.Tensor()
+    assert x.device == y.device and x.device == output.device
+    n_elements = output.numel()
+
+    def grid(META): return (triton.cdiv(n_elements, META['BLOCK_SIZE']), )
+
+    nrm2_kernel[grid](
+        x,
+        output,
+        n_elements
+    )
+    
+    return output


### PR DESCRIPTION
Update and use consistent DEVICE as defined in the tutorial. Have cuda even on rocm per Alessandro

`DEVICE = triton.runtime.driver.active.get_active_torch_device()
`